### PR TITLE
Set the stateless relation property to true

### DIFF
--- a/src/reactive/cinder_backup_nfs.py
+++ b/src/reactive/cinder_backup_nfs.py
@@ -32,6 +32,8 @@ def configure_cinder_backup():
         if None in (name, config):
             return
         endp.publish(name, config)
+        for relation in endp.relations:
+            relation.to_publish['stateless'] = True
         charm_instance.configure_ca()
         flags.set_flag('config.complete')
 


### PR DESCRIPTION
This charm does not manage state. Setting stateless to `True` makes the cinder charm properly set the `host` option in the `DEFAULT` section.